### PR TITLE
Fix SSH key legacy fact matching

### DIFF
--- a/lib/puppet-lint/plugins/legacy_facts.rb
+++ b/lib/puppet-lint/plugins/legacy_facts.rb
@@ -8,7 +8,7 @@ PuppetLint.new_check(:legacy_facts) do
                  /^(?<attribute>ipaddress|ipaddress6|macaddress|mtu|netmask|netmask6|network|network6)_(?<interface>.*)$/,
                  /^processor(?<id>[0-9]+)$/,
                  /^sp_(?<name>.*)$/,
-                 /^ssh(?<algorithm>.*)key$/,
+                 /^ssh(?<algorithm>[a-z0-9]*)key$/,
                  /^ldom_(?<name>.*)$/,
                  /^zone_(?<name>.*)_(?<attribute>brand|iptype|name|uuid|id|path|status)$/]
 
@@ -118,7 +118,7 @@ PuppetLint.new_check(:legacy_facts) do
         problem[:token].value = "facts['processors']['models'][" << m['id'] << "]"
       elsif m = fact_name.match(/^sp_(?<name>.*)$/)
         problem[:token].value = "facts['system_profiler']['" << m['name'] << "']"
-      elsif m = fact_name.match(/^ssh(?<algorithm>.*)key$/)
+      elsif m = fact_name.match(/^ssh(?<algorithm>[a-z0-9]*)key$/)
         problem[:token].value = "facts['ssh']['" << m['algorithm'] << "']['key']"
       elsif m = fact_name.match(/^ldom_(?<name>.*)$/)
         problem[:token].value = "facts['ldom']['" << m['name'] << "']"

--- a/spec/puppet-lint/plugins/legacy_facts_spec.rb
+++ b/spec/puppet-lint/plugins/legacy_facts_spec.rb
@@ -11,6 +11,14 @@ describe 'legacy_facts' do
       end
     end
 
+    context "fact variable using modern $facts['ssh']['rsa']['key'] hash" do
+      let(:code) { "$facts['ssh']['rsa']['key']" }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problem
+      end
+    end
+
     context "fact variable using legacy $osfamily" do
       let(:code) { "$osfamily" }
 
@@ -102,6 +110,14 @@ describe 'legacy_facts' do
       end
     end
 
+    context "fact variable using modern $facts['ssh']['rsa']['key'] hash" do
+      let(:code) { "$facts['ssh']['rsa']['key']" }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problem
+      end
+    end
+
     context "fact variable using legacy $osfamily" do
       let(:code) { "$osfamily" }
 
@@ -139,6 +155,22 @@ describe 'legacy_facts' do
 
       it 'should use the facts hash' do
         expect(manifest).to eq("$facts['os']['family']")
+      end
+    end
+
+    context "fact variable using legacy $::sshrsakey" do
+      let(:code) { "$::sshrsakey" }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should fix the problem' do
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(1)
+      end
+
+      it 'should use the facts hash' do
+        expect(manifest).to eq("$facts['ssh']['rsa']['key']")
       end
     end
 


### PR DESCRIPTION
The regular expression that is supposed to match legacy SSH key facts also matches their modern replacements (as can be seen [here](http://rubular.com/r/d2aerdOGkn)). As a result puppet-lint returns a false-positive. This patch fixes the issue and adds additional spec tests.