### PR TITLE
Fix correction of facts contained in strings

### DIFF
--- a/lib/puppet-lint/plugins/legacy_facts.rb
+++ b/lib/puppet-lint/plugins/legacy_facts.rb
@@ -102,6 +102,9 @@ PuppetLint.new_check(:legacy_facts) do
   end
 
   def fix(problem)
+    # This probably should never occur, but if it does then bail out:
+    raise PuppetLint::NoFix if problem[:token].raw and problem[:token].value != problem[:token].raw
+
     if problem[:token].value.start_with?('::') then
       fact_name = problem[:token].value.sub(/^::/, '')
     elsif problem[:token].value.start_with?("facts['") then
@@ -126,5 +129,7 @@ PuppetLint.new_check(:legacy_facts) do
         problem[:token].value = "facts['solaris_zones']['zones']['" << m['name'] << "']['" << m['attribute'] << "']"
       end
     end
+
+    problem[:token].raw = problem[:token].value unless problem[:token].raw.nil?
   end
 end

--- a/spec/puppet-lint/plugins/legacy_facts_spec.rb
+++ b/spec/puppet-lint/plugins/legacy_facts_spec.rb
@@ -90,6 +90,14 @@ describe 'legacy_facts' do
         expect(problems).to have(1).problem
       end
     end
+
+    context "fact variable in interpolated string \"${::osfamily}\"" do
+      let(:code) { '"start ${::osfamily} end"' }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+    end
   end
 
 
@@ -249,6 +257,18 @@ describe 'legacy_facts' do
       end
       it 'should use the facts hash' do
         expect(manifest).to eq("$facts['ssh']['rsa']['key']")
+      end
+    end
+
+    context "fact variable in interpolated string \"${::osfamily}\"" do
+      let(:code) { '"start ${::osfamily} end"' }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should use the facts hash' do
+        expect(manifest).to eq('"start '"${facts['os']['family']}"' end"')
       end
     end
   end


### PR DESCRIPTION
Tokens for variables contained in certain contexts (such as
double-quoted strings and heredocs) contain a "raw" value which,
if set, is used in preference to the "value" value. If raw is set
and matches the value, this patch then fixes the raw value as well.