### PR TITLE
Avoid already initialized constant error

### DIFF
--- a/lib/puppet-lint/plugins/legacy_facts.rb
+++ b/lib/puppet-lint/plugins/legacy_facts.rb
@@ -1,5 +1,5 @@
 PuppetLint.new_check(:legacy_facts) do
-  VAR_TYPES = Set[:VARIABLE, :UNENC_VARIABLE]
+  LEGACY_FACTS_VAR_TYPES = Set[:VARIABLE, :UNENC_VARIABLE]
 
   # These facts that can't be converted to new facts for reasons documented at
   # https://github.com/mmckinst/puppet-lint-legacy_facts-check#limitations
@@ -97,7 +97,7 @@ PuppetLint.new_check(:legacy_facts) do
     'zonename'                    => "facts['solaris_zones']['current']",
   }
   def check
-    tokens.select { |x| VAR_TYPES.include?(x.type) }.each do |token|
+    tokens.select { |x| LEGACY_FACTS_VAR_TYPES.include?(x.type) }.each do |token|
       fact_name = ''
 
       # Get rid of the top scope before we do our work. We don't need to


### PR DESCRIPTION
A simple workaround for:

```
~/.pdk/cache/ruby/2.1.0/gems/puppet-lint-legacy_facts-check-1.0.1/lib/puppet-lint/plugins/legacy_facts.rb:2: warning: previous definition of VAR_TYPES was here
```
