### PR TITLE
Update to work with puppet-lint >= 2.4

### DIFF
--- a/puppet-lint-legacy_facts-check.gemspec
+++ b/puppet-lint-legacy_facts-check.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   `$facts['os']['name']` instead
   EOF
 
-  spec.add_dependency             'puppet-lint', '2.3.6'
+  spec.add_dependency             'puppet-lint', '~> 2.4'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-json_expectations'

--- a/spec/puppet-lint/plugins/legacy_facts_spec.rb
+++ b/spec/puppet-lint/plugins/legacy_facts_spec.rb
@@ -106,6 +106,14 @@ describe 'legacy_facts' do
         expect(problems).to have(1).problem
       end
     end
+
+    context 'fact variable using legacy facts hash variable in interpolation' do
+      let(:code) { %("${facts['osfamily']}") }
+
+      it 'detects a single problem' do
+        expect(problems).to have(1).problem
+      end
+    end
   end
 
 
@@ -389,6 +397,17 @@ describe 'legacy_facts' do
 
       it 'should use the facts hash' do
         expect(manifest).to eq("\"$facts['os']['distro']['release']['specification']\"")
+      end
+    end
+    context "fact variable using facts hash in double quotes \"$facts['lsbrelease']\"" do
+      let(:code) { "\"${facts['lsbrelease']}\"" }
+
+      it 'should only detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should use the facts hash' do
+        expect(manifest).to eq("\"${facts['os']['distro']['release']['specification']}\"")
       end
     end
   end


### PR DESCRIPTION
puppet-lint 2.4 introduced what was supposed to be a non-breaking change
that fixed how interpolated expressions were tokenised, but this
unfortunately broke the check in this plugin (I'm going to have to
rethink how plugins factor into my change classifications for semver
purposes).

Anyway, this PR should fix up the issues with this plugin and
puppet-lint 2.4.x by extending the existing logic to handle cases where
variables like `$facts['osfamily']` are represented internally as
a sequence of tokens rather than a single token.