### PR TITLE
make examples in documentation consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $package_name = $facts['operatingsystem'] {
 #### What you should have done
 
 ```puppet
-$service_name = $facts['os']['name'] {
+$package_name = $facts['os']['name'] {
   'CentOS' => 'httpd',
   'Debian' => 'apache2',
 }


### PR DESCRIPTION
All the examples of what not to do use package_name but the example of what to
do uses service_name. This makes everything use package_name.