### PR TITLE
Include the legacy fact name in the error message

### DIFF
--- a/lib/puppet-lint/plugins/legacy_facts.rb
+++ b/lib/puppet-lint/plugins/legacy_facts.rb
@@ -125,7 +125,7 @@ PuppetLint.new_check(:legacy_facts) do
 
       if EASY_FACTS.include?(fact_name) or UNCONVERTIBLE_FACTS.include?(fact_name) or fact_name.match(Regexp.union(REGEX_FACTS)) then
         notify :warning, {
-          :message   => 'legacy fact',
+          :message   => "legacy fact '#{fact_name}'",
           :line      => token.line,
           :column    => token.column,
           :token     => token,


### PR DESCRIPTION
puppet-lint now outputs the fact name in the error message, like below, making it easier to identify what needs to change:

    manifests/init.pp - WARNING: legacy fact 'architecture' on line 102 (check: legacy_facts)