### PR TITLE
(maint) Update README limitation - unable to scan custom facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ $package_name = $facts['operatingsystem'] {
 
 ## Limitations
 
+The linter can only scan known facts in the codebase, custom facts cannot be scanned.
+
 The linter will only find and work on top scope facts like `$::osfamily`,
 non-top scope facts like `$osfamily` will not be found or fixed. 
 


### PR DESCRIPTION
Adding in a section to highlight that the plugin will not scan custom facts. Custom facts are not predictable therefore scanning an unpredictable fact becomes impossible.